### PR TITLE
feat: add digitalocean TF provider

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -6,6 +6,7 @@
   "azurerm": "azurerm@~> 2.0",
   "cloudinit": "hashicorp/cloudinit@~> 2.2.0",
   "datadog": "DataDog/datadog@~> 3.0",
+  "digitalocean": "digitalocean/digitalocean@~> 2.19",
   "docker": "kreuzwerker/docker@~> 2.12",
   "external": "external@~> 2.1",
   "github": "integrations/github@~> 4.0",


### PR DESCRIPTION
In relation to https://github.com/hashicorp/terraform-cdk/issues/1712 this adds the DigitalOcean Terraform provider.