### PR TITLE
chore(deps): upgrade TFE provider

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -29,7 +29,7 @@
   "snowflake": "chanzuckerberg/snowflake@ ~> 0.25",
   "spotinst": "spotinst/spotinst@~> 1.0",
   "template": "hashicorp/template@~> 2.2",
-  "tfe": "hashicorp/tfe@~> 0.32.1",
+  "tfe": "hashicorp/tfe@~> 0.33.0",
   "time": "hashicorp/time@~> 0.7",
   "tls": "hashicorp/tls@~> 3.1",
   "upcloud": "UpCloudLtd/upcloud@~> 2.4",


### PR DESCRIPTION
This CDKTF pre-built TFE provider just introduced variable set support with v0.32.1, which is now deprecated in v0.33.0.