### PR TITLE
remove Yandex Cloud from prebuilt providers

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -34,6 +34,5 @@
   "time": "hashicorp/time@~> 0.7",
   "tls": "hashicorp/tls@~> 4.0",
   "upcloud": "UpCloudLtd/upcloud@~> 2.4",
-  "vault": "hashicorp/vault@~> 3.7",
-  "yandex": "yandex-cloud/yandex@~> 0.73"
+  "vault": "hashicorp/vault@~> 3.7"
 }


### PR DESCRIPTION
We've made the decision to remove Yandex Cloud from our prebuilt provider offering based on an internal request. Users can still locally build the Yandex Cloud provider if they need it.