### PR TITLE
fix!: Due to an accidentally introduced incompatibility in cdktf 0.12.2, the latest pre-built providers now require at least cdktf 0.12.2

### DIFF
--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -1,7 +1,7 @@
 const { CdktfProviderProject } = require("@cdktf/provider-project");
 const project = new CdktfProviderProject({
   terraformProvider: "__PROVIDER__",
-  cdktfVersion: "^0.12.0",
+  cdktfVersion: "^0.12.2",
   constructsVersion: "^10.0.0",
   minNodeVersion: "14.17.0",
   jsiiVersion: "^1.53.0",


### PR DESCRIPTION
Due to an accidentally introduced incompatibility in cdktf 0.12.2, the latest pre-built providers now require at least cdktf 0.12.2