### PR TITLE
feat: set useCustomGithubRunner option for some providers

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -45,8 +45,10 @@ jobs:
             const fs = require('fs')
             const provider = require('./main/provider.json')
             const providerVersion = provider["${{ matrix.provider }}"]
+            const providersWithCustomRunners = require('./main/providersWithCustomRunners.json')
+            const useCustomGithubRunner = providersWithCustomRunners.includes("${{ matrix.provider }}");
             const template = fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'main', 'projenrc.template.js'), 'utf-8')
-            const projenrc = template.replace('__PROVIDER__', providerVersion)
+            const projenrc = template.replace('__PROVIDER__', providerVersion).replace('__CUSTOM_RUNNER__', useCustomGithubRunner)
             fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, 'provider', '.projenrc.js'), projenrc)
       - name: Upgrade provider project
         run: |

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -1,5 +1,6 @@
 const { CdktfProviderProject } = require("@cdktf/provider-project");
 const project = new CdktfProviderProject({
+  useCustomGithubRunner: __CUSTOM_RUNNER__,
   terraformProvider: "__PROVIDER__",
   cdktfVersion: "^0.12.2",
   constructsVersion: "^10.0.0",

--- a/providersWithCustomRunners.json
+++ b/providersWithCustomRunners.json
@@ -1,0 +1,1 @@
+["azurerm", "google", "googlebeta", "kubernetes"]


### PR DESCRIPTION
DO NOT MERGE
... until https://github.com/hashicorp/cdktf-provider-project/pull/247 has been merged and released. Because this PR adds an currently unknown option to the Projen project and we first need to update the Projen project version itself (using the very same command that we change in this PR)

Else we'd need to manually update the Projen project version in all 38 provider repositories 😅