### PR TITLE
Add hashicups as a prebuilt provider for testing provider migration

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -34,5 +34,6 @@
   "time": "hashicorp/time@~> 0.7",
   "tls": "hashicorp/tls@~> 4.0",
   "upcloud": "UpCloudLtd/upcloud@~> 2.4",
-  "vault": "hashicorp/vault@~> 3.7"
+  "vault": "hashicorp/vault@~> 3.7",
+  "hashicups": "hashicorp/hashicups@~> 0.3"
 }

--- a/provider.json
+++ b/provider.json
@@ -16,6 +16,7 @@
   "gitlab": "gitlabhq/gitlab@~> 3.14",
   "google": "google@~> 4.0",
   "googlebeta": "google-beta@~> 4.17",
+  "hashicups": "hashicorp/hashicups@~> 0.3",
   "helm": "helm@~> 2.3",
   "ionoscloud": "ionos-cloud/ionoscloud@~> 6.2",
   "kubernetes": "kubernetes@~> 2.0",
@@ -34,6 +35,5 @@
   "time": "hashicorp/time@~> 0.7",
   "tls": "hashicorp/tls@~> 4.0",
   "upcloud": "UpCloudLtd/upcloud@~> 2.4",
-  "vault": "hashicorp/vault@~> 3.7",
-  "hashicups": "hashicorp/hashicups@~> 0.3"
+  "vault": "hashicorp/vault@~> 3.7"
 }


### PR DESCRIPTION
Related to: https://github.com/hashicorp/terraform-cdk/issues/2135

This PR imports the [hashicups](https://github.com/hashicorp/terraform-provider-hashicups) provider. We will use this provider to test the migration steps of prebuilt-providers, to prevent any accidental outages.