### PR TITLE
feat: enable ^0.12.2 bindings to work with the next cdktf version (^0.13.0)

### DIFF
--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -2,7 +2,7 @@ const { CdktfProviderProject } = require("@cdktf/provider-project");
 const project = new CdktfProviderProject({
   useCustomGithubRunner: __CUSTOM_RUNNER__,
   terraformProvider: "__PROVIDER__",
-  cdktfVersion: "^0.12.2",
+  cdktfVersion: "^0.12.2 || ^0.13.0",
   constructsVersion: "^10.0.0",
   minNodeVersion: "14.17.0",
   jsiiVersion: "^1.53.0",


### PR DESCRIPTION
Note: The breaking change detection when rolling out this change will still work (and *not* detect a breaking change for this change), as it parses only the first valid version which in this case will end up being `0.12.2`. Refer to the used regex here: https://github.com/hashicorp/cdktf-repository-manager/blob/955b2c051e981266fc4ae4118424f0d694714147/.github/workflows/upgrade-repositories.yml#L91

The provider add command supports these advanced version ranges as well because it uses the semver package to check if the used cdktf version satisfies the range from the published package: https://github.com/hashicorp/terraform-cdk/blob/550d0cc927df1a62d69acdb184576ec3a583e5f8/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts#L204