### PR TITLE
fix: use correct org name for prebuilt providers in action

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          repository: hashicorp/cdktf-provider-${{ matrix.provider }}
+          repository: cdktf/cdktf-provider-${{ matrix.provider }}
           token: ${{ secrets.GH_COMMENT_TOKEN }}
           path: provider
       - uses: actions/github-script@v4
@@ -167,7 +167,7 @@ jobs:
             const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env
             const url = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
             const repo = "cdktf-provider-${{ matrix.provider }}"
-            const owner = 'hashicorp'
+            const owner = 'cdktf'
             const { data } = await github.pulls.create({
               owner,
               repo,


### PR DESCRIPTION
Since we've moved all the pre-built providers to the `cdktf` Github organization, and the new official pre-built providers were never a part of the `hashicorp` Github org, this PR will update the `upgrade-repositories` github action workflow to reference the current repository URL.