### PR TITLE
chore: Name deploy and diff workflows differently

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: "Repository Manager"
+name: "Deploy"
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,4 +1,4 @@
-name: "Repository Manager"
+name: "Plan"
 
 on: [pull_request]
 


### PR DESCRIPTION
Currently both workflows show up as 'Repository Manager' in the Github user interface. This should fix that.